### PR TITLE
Fix window grouping in firefox in GNOME

### DIFF
--- a/src/common.py
+++ b/src/common.py
@@ -268,6 +268,7 @@ class WebAppManager:
             exec_string = (
                 "sh -c 'XAPP_FORCE_GTKWINDOW_ICON=\"" + icon + "\" " + browser.exec_path +
                 " --class WebApp-" + codename +
+                " --name WebApp-" + codename +
                 " --profile " + firefox_profile_path +
                 " --no-remote "
             )


### PR DESCRIPTION
All webapps made with firefox are grouped with main firefox browser in GNOME, which should not be the case. This commit fixes. The solution has been suggested a multiple times, which mint's team was too inactive to see and merge.
I always used to add the ```--name ``` argument myself in the desktop apps created by mint's webapp-manager, in that case they work in GNOME and are not grouped with firefox window.